### PR TITLE
Change owner, Docker socket from root -> vagrant, non-sudo docker access

### DIFF
--- a/ansible/roles/docker/tasks/setup-Debian.yml
+++ b/ansible/roles/docker/tasks/setup-Debian.yml
@@ -34,3 +34,12 @@
 - name: Install docker-compose
   pip: name=docker-compose
   tags: docker
+
+- name: Grant /var/run/docker.sock ownership to current user
+  file:
+    path: /var/run/docker.sock
+    owner: vagrant
+    group: vagrant
+    mode: 0777  
+  tags:
+    - docker


### PR DESCRIPTION
Docker socket /var/run/docker.sock default owner is root, trying to use via vagrant gives permission denied.
This commit will change socket owner to vagrant so that we can access docker command without sudo. 
